### PR TITLE
#1 fix stair collision

### DIFF
--- a/Scenes/player.tscn
+++ b/Scenes/player.tscn
@@ -12,6 +12,7 @@ height = 1.8
 
 [node name="Player" type="CharacterBody3D"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 10.128, 0)
+floor_max_angle = 0.872665
 script = ExtResource("1_6p5hj")
 
 [node name="MeshInstance3D" type="MeshInstance3D" parent="."]


### PR DESCRIPTION
The slope of the stairs - or more specifically the stairs' collision shape - is 45 degrees, and the collision surface is made of two triangles so there is a diagonal seam on the surface. The player was getting stuck when crossing this seam because the player's CharacterBody3D was set to allow a maximum angle of 45 degrees and due to rounding errors this would sometimes report a tiny fraction over 45 degrees (e.g. 45.001 degrees), so the player would stop.

This change sets the player's CharacterBody3D to allow a maximum floor angle of 50 degrees (or 0.873 radians).